### PR TITLE
Support mosn as a sidecar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@
 -include Makefile.overrides.mk
 
 
-# Dynamic set sidcar
-# Now it support Envoy and MOSN, if set SIDCAR = MOSN, MOSN will be used as the proxy in Istio.
-export SIDCAR = MOSN
+# Dynamic set sidecar
+# Now it support Envoy and MOSN, if set SIDECAR = MOSN, MOSN will be used as the proxy in Istio.
+export SIDECAR = MOSN
 export ISTIO_MOSN_VERSION = 0.9.0
 
 # Set the environment variable BUILD_WITH_CONTAINER to use a container

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,12 @@
 # allow optional per-repo overrides
 -include Makefile.overrides.mk
 
+
+# Dynamic set sidcar
+# Now it support Envoy and MOSN, if set SIDCAR = MOSN, MOSN will be used as the proxy in Istio.
+export SIDCAR = MOSN
+export ISTIO_MOSN_VERSION = 0.9.0
+
 # Set the environment variable BUILD_WITH_CONTAINER to use a container
 # to build the repo. The only dependencies in this mode are to have make and
 # docker. If you'd rather build with a local tool chain instead, you'll need to

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -162,7 +162,7 @@ ifeq ($(PROXY_REPO_SHA),)
   export PROXY_REPO_SHA:=$(shell grep PROXY_REPO_SHA istio.deps  -A 4 | grep lastStableSHA | cut -f 4 -d '"')
 endif
 
-ifeq ($(SIDCAR), Envoy)
+ifeq ($(SIDECAR), Envoy)
   # Envoy binary variables Keep the default URLs up-to-date with the latest push from istio/proxy.
   
   export ISTIO_ENVOY_BASE_URL ?= https://storage.googleapis.com/istio-build/proxy
@@ -211,7 +211,7 @@ ifeq ($(SIDCAR), Envoy)
 endif
 
 
-ifeq ($(SIDCAR), MOSN)
+ifeq ($(SIDECAR), MOSN)
   # Defines the base URL to download mosn from
   export ISTIO_MOSN_BASE_URL ?= https://github.com/mosn/mosn/releases/download/
 

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -162,51 +162,86 @@ ifeq ($(PROXY_REPO_SHA),)
   export PROXY_REPO_SHA:=$(shell grep PROXY_REPO_SHA istio.deps  -A 4 | grep lastStableSHA | cut -f 4 -d '"')
 endif
 
-# Envoy binary variables Keep the default URLs up-to-date with the latest push from istio/proxy.
-
-export ISTIO_ENVOY_BASE_URL ?= https://storage.googleapis.com/istio-build/proxy
-
-# OS-neutral vars. These currently only work for linux.
-export ISTIO_ENVOY_VERSION ?= ${PROXY_REPO_SHA}
-export ISTIO_ENVOY_DEBUG_URL ?= $(ISTIO_ENVOY_BASE_URL)/envoy-debug-$(ISTIO_ENVOY_VERSION).tar.gz
-export ISTIO_ENVOY_RELEASE_URL ?= $(ISTIO_ENVOY_BASE_URL)/envoy-alpha-$(ISTIO_ENVOY_VERSION).tar.gz
-
-# Envoy Linux vars.
-export ISTIO_ENVOY_LINUX_VERSION ?= ${ISTIO_ENVOY_VERSION}
-export ISTIO_ENVOY_LINUX_DEBUG_URL ?= ${ISTIO_ENVOY_DEBUG_URL}
-export ISTIO_ENVOY_LINUX_RELEASE_URL ?= ${ISTIO_ENVOY_RELEASE_URL}
-# Variables for the extracted debug/release Envoy artifacts.
-export ISTIO_ENVOY_LINUX_DEBUG_DIR ?= ${OUT_DIR}/linux_amd64/debug
-export ISTIO_ENVOY_LINUX_DEBUG_NAME ?= envoy-debug-${ISTIO_ENVOY_LINUX_VERSION}
-export ISTIO_ENVOY_LINUX_DEBUG_PATH ?= ${ISTIO_ENVOY_LINUX_DEBUG_DIR}/${ISTIO_ENVOY_LINUX_DEBUG_NAME}
-export ISTIO_ENVOY_LINUX_RELEASE_DIR ?= ${OUT_DIR}/linux_amd64/release
-export ISTIO_ENVOY_LINUX_RELEASE_NAME ?= envoy-${ISTIO_ENVOY_VERSION}
-export ISTIO_ENVOY_LINUX_RELEASE_PATH ?= ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/${ISTIO_ENVOY_LINUX_RELEASE_NAME}
-
-# Envoy macOS vars.
-# TODO Change url when official envoy release for macOS is available
-export ISTIO_ENVOY_MACOS_VERSION ?= 1.0.2
-export ISTIO_ENVOY_MACOS_RELEASE_URL ?= https://github.com/istio/proxy/releases/download/${ISTIO_ENVOY_MACOS_VERSION}/istio-proxy-${ISTIO_ENVOY_MACOS_VERSION}-macos.tar.gz
-# Variables for the extracted debug/release Envoy artifacts.
-export ISTIO_ENVOY_MACOS_RELEASE_DIR ?= ${OUT_DIR}/darwin_amd64/release
-export ISTIO_ENVOY_MACOS_RELEASE_NAME ?= envoy-${ISTIO_ENVOY_MACOS_VERSION}
-export ISTIO_ENVOY_MACOS_RELEASE_PATH ?= ${ISTIO_ENVOY_MACOS_RELEASE_DIR}/${ISTIO_ENVOY_MACOS_RELEASE_NAME}
-
-# Allow user-override for a local Envoy build.
-export USE_LOCAL_PROXY ?= 0
-ifeq ($(USE_LOCAL_PROXY),1)
-  export ISTIO_ENVOY_LOCAL ?= $(realpath ${ISTIO_GO}/../proxy/bazel-bin/src/envoy/envoy)
-  # Point the native paths to the local envoy build.
-  ifeq ($(GOOS_LOCAL), Darwin)
-    export ISTIO_ENVOY_MACOS_RELEASE_DIR = $(dir ${ISTIO_ENVOY_LOCAL})
-    export ISTIO_ENVOY_MACOS_RELEASE_PATH = ${ISTIO_ENVOY_LOCAL}
-  else
-    export ISTIO_ENVOY_LINUX_DEBUG_DIR = $(dir ${ISTIO_ENVOY_LOCAL})
-    export ISTIO_ENVOY_LINUX_RELEASE_DIR = $(dir ${ISTIO_ENVOY_LOCAL})
-    export ISTIO_ENVOY_LINUX_DEBUG_PATH = ${ISTIO_ENVOY_LOCAL}
-    export ISTIO_ENVOY_LINUX_RELEASE_PATH = ${ISTIO_ENVOY_LOCAL}
+ifeq ($(SIDCAR), Envoy)
+  # Envoy binary variables Keep the default URLs up-to-date with the latest push from istio/proxy.
+  
+  export ISTIO_ENVOY_BASE_URL ?= https://storage.googleapis.com/istio-build/proxy
+  
+  # OS-neutral vars. These currently only work for linux.
+  export ISTIO_ENVOY_VERSION ?= ${PROXY_REPO_SHA}
+  export ISTIO_ENVOY_DEBUG_URL ?= $(ISTIO_ENVOY_BASE_URL)/envoy-debug-$(ISTIO_ENVOY_VERSION).tar.gz
+  export ISTIO_ENVOY_RELEASE_URL ?= $(ISTIO_ENVOY_BASE_URL)/envoy-alpha-$(ISTIO_ENVOY_VERSION).tar.gz
+  
+  # Envoy Linux vars.
+  export ISTIO_ENVOY_LINUX_VERSION ?= ${ISTIO_ENVOY_VERSION}
+  export ISTIO_ENVOY_LINUX_DEBUG_URL ?= ${ISTIO_ENVOY_DEBUG_URL}
+  export ISTIO_ENVOY_LINUX_RELEASE_URL ?= ${ISTIO_ENVOY_RELEASE_URL}
+  # Variables for the extracted debug/release Envoy artifacts.
+  export ISTIO_ENVOY_LINUX_DEBUG_DIR ?= ${OUT_DIR}/linux_amd64/debug
+  export ISTIO_ENVOY_LINUX_DEBUG_NAME ?= envoy-debug-${ISTIO_ENVOY_LINUX_VERSION}
+  export ISTIO_ENVOY_LINUX_DEBUG_PATH ?= ${ISTIO_ENVOY_LINUX_DEBUG_DIR}/${ISTIO_ENVOY_LINUX_DEBUG_NAME}
+  export ISTIO_ENVOY_LINUX_RELEASE_DIR ?= ${OUT_DIR}/linux_amd64/release
+  export ISTIO_ENVOY_LINUX_RELEASE_NAME ?= envoy-${ISTIO_ENVOY_VERSION}
+  export ISTIO_ENVOY_LINUX_RELEASE_PATH ?= ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/${ISTIO_ENVOY_LINUX_RELEASE_NAME}
+  
+  # Envoy macOS vars.
+  # TODO Change url when official envoy release for macOS is available
+  export ISTIO_ENVOY_MACOS_VERSION ?= 1.0.2
+  export ISTIO_ENVOY_MACOS_RELEASE_URL ?= https://github.com/istio/proxy/releases/download/${ISTIO_ENVOY_MACOS_VERSION}/istio-proxy-${ISTIO_ENVOY_MACOS_VERSION}-macos.tar.gz
+  # Variables for the extracted debug/release Envoy artifacts.
+  export ISTIO_ENVOY_MACOS_RELEASE_DIR ?= ${OUT_DIR}/darwin_amd64/release
+  export ISTIO_ENVOY_MACOS_RELEASE_NAME ?= envoy-${ISTIO_ENVOY_MACOS_VERSION}
+  export ISTIO_ENVOY_MACOS_RELEASE_PATH ?= ${ISTIO_ENVOY_MACOS_RELEASE_DIR}/${ISTIO_ENVOY_MACOS_RELEASE_NAME}
+  
+  # Allow user-override for a local Envoy build.
+  export USE_LOCAL_PROXY ?= 0
+  ifeq ($(USE_LOCAL_PROXY),1)
+    export ISTIO_ENVOY_LOCAL ?= $(realpath ${ISTIO_GO}/../proxy/bazel-bin/src/envoy/envoy)
+    # Point the native paths to the local envoy build.
+    ifeq ($(GOOS_LOCAL), Darwin)
+      export ISTIO_ENVOY_MACOS_RELEASE_DIR = $(dir ${ISTIO_ENVOY_LOCAL})
+      export ISTIO_ENVOY_MACOS_RELEASE_PATH = ${ISTIO_ENVOY_LOCAL}
+    else
+      export ISTIO_ENVOY_LINUX_DEBUG_DIR = $(dir ${ISTIO_ENVOY_LOCAL})
+      export ISTIO_ENVOY_LINUX_RELEASE_DIR = $(dir ${ISTIO_ENVOY_LOCAL})
+      export ISTIO_ENVOY_LINUX_DEBUG_PATH = ${ISTIO_ENVOY_LOCAL}
+      export ISTIO_ENVOY_LINUX_RELEASE_PATH = ${ISTIO_ENVOY_LOCAL}
+    endif
   endif
 endif
+
+
+ifeq ($(SIDCAR), MOSN)
+  # Defines the base URL to download mosn from
+  export ISTIO_MOSN_BASE_URL ?= https://github.com/mosn/mosn/releases/download/
+
+  # These variables are normally set by the Makefile.
+  # OS-neutral vars. These currently only work for linux.
+  export ISTIO_MOSN_VERSION ?= ${PROXY_REPO_SHA}
+  export ISTIO_MOSN_DEBUG_URL ?= $(ISTIO_MOSN_BASE_URL)/$(ISTIO_MOSN_VERSION)/mosn
+  export ISTIO_MOSN_RELEASE_URL ?= $(ISTIO_MOSN_BASE_URL)/$(ISTIO_MOSN_VERSION)/mosn
+
+  # MOSN Linux vars. Normally set by the Makefile.
+  export ISTIO_MOSN_LINUX_VERSION ?= ${ISTIO_MOSN_VERSION}
+  export ISTIO_MOSN_LINUX_DEBUG_URL ?= ${ISTIO_MOSN_DEBUG_URL}
+  export ISTIO_MOSN_LINUX_RELEASE_URL ?= ${ISTIO_MOSN_RELEASE_URL}
+  # Variables for the extracted debug/release MOSN artifacts.
+  export ISTIO_MOSN_LINUX_DEBUG_DIR ?= ${OUT_DIR}/linux_amd64/debug
+  export ISTIO_MOSN_LINUX_DEBUG_NAME ?= mosn-debug-${ISTIO_MOSN_LINUX_VERSION}
+  export ISTIO_MOSN_LINUX_DEBUG_PATH ?= $(ISTIO_MOSN_LINUX_DEBUG_DIR)/$(ISTIO_MOSN_LINUX_DEBUG_NAME)
+  export ISTIO_MOSN_LINUX_RELEASE_DIR ?= ${OUT_DIR}/linux_amd64/release
+  export ISTIO_MOSN_LINUX_RELEASE_NAME ?= mosn-${ISTIO_MOSN_LINUX_VERSION}
+  export ISTIO_MOSN_LINUX_RELEASE_PATH ?= $(ISTIO_MOSN_LINUX_RELEASE_DIR)/$(ISTIO_MOSN_LINUX_RELEASE_NAME)
+
+  # MOSN macOS vars. Normally set by the makefile.
+  # TODO Change url when official MOSN release for macOS is available
+  export ISTIO_MOSN_MACOS_VERSION = 0.9.0
+  export ISTIO_MOSN_MACOS_RELEASE_URL ?= https://github.com/mosn/mosn/releases/download/${ISTIO_MOSN_MACOS_VERSION}/mosn
+  # Variables for the extracted debug/release MOSN artifacts.
+  export ISTIO_MOSN_MACOS_RELEASE_DIR ?= ${OUT_DIR}/release
+  export ISTIO_MOSN_MACOS_RELEASE_NAME ?= mosn-${ISTIO_MOSN_MACOS_VERSION}
+  export ISTIO_MOSN_MACOS_RELEASE_PATH ?= $(ISTIO_MOSN_MACOS_RELEASE_DIR)/$(ISTIO_MOSN_MACOS_RELEASE_NAME)
+endif 
 
 GO_VERSION_REQUIRED:=1.10
 

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -90,7 +90,7 @@ function download_envoy_if_necessary () {
     mkdir -p "$(dirname "$2")"
     pushd "$(dirname "$2")"
 
-    if [ $SIDCAR = "Envoy" ] ; then     
+    if [ $SIDECAR = "Envoy" ] ; then     
       # Download and extract the binary to the output directory.
       echo "Downloading Envoy: ${DOWNLOAD_COMMAND} $1 to $2"
       time ${DOWNLOAD_COMMAND} --header "${AUTH_HEADER:-}" "$1" | tar xz
@@ -106,7 +106,7 @@ function download_envoy_if_necessary () {
       cp -f "$2" "$(dirname "$2")/envoy"
     fi  
 
-    if [ $SIDCAR = "MOSN" ] ; then     
+    if [ $SIDECAR = "MOSN" ] ; then     
       # Download and extract the binary to the output directory.
       echo "Downloading MOSN: ${DOWNLOAD_COMMAND} $1 to $2"
       time ${DOWNLOAD_COMMAND} --header "${AUTH_HEADER:-}" "$1" > mosn
@@ -134,7 +134,7 @@ if [[ -z "${PROXY_REPO_SHA:-}" ]] ; then
   export PROXY_REPO_SHA
 fi
 
-if [ $SIDCAR = "Envoy" ] ; then 
+if [ $SIDECAR = "Envoy" ] ; then 
   # Defines the base URL to download envoy from
   ISTIO_ENVOY_BASE_URL=${ISTIO_ENVOY_BASE_URL:-https://storage.googleapis.com/istio-build/proxy}
   
@@ -196,7 +196,7 @@ if [ $SIDCAR = "Envoy" ] ; then
 fi
 
 
-if [ $SIDCAR = "MOSN" ] ; then 
+if [ $SIDECAR = "MOSN" ] ; then 
   # Defines the base URL to download mosn from
   ISTIO_MOSN_BASE_URL=${ISTIO_MOSN_BASE_URL:-https://github.com/mosn/mosn/releases/download/}
   
@@ -238,24 +238,24 @@ set_download_command
 
 
 # Download and extract the Envoy linux debug binary.
-#download_envoy_if_necessary "${ISTIO_SIDCAR_LINUX_DEBUG_URL}" "$ISTIO_SIDCAR_LINUX_DEBUG_PATH"
-download_envoy_if_necessary `eval echo '$ISTIO_'"${SIDCAR}"'_LINUX_DEBUG_URL'` `eval echo '$ISTIO_'"${SIDCAR}"'_LINUX_DEBUG_PATH'`
+#download_envoy_if_necessary "${ISTIO_SIDECAR_LINUX_DEBUG_URL}" "$ISTIO_SIDECAR_LINUX_DEBUG_PATH"
+download_envoy_if_necessary `eval echo '$ISTIO_'"${SIDECAR}"'_LINUX_DEBUG_URL'` `eval echo '$ISTIO_'"${SIDECAR}"'_LINUX_DEBUG_PATH'`
 
 # Download and extract the Envoy linux release binary.
-download_envoy_if_necessary `eval echo '$ISTIO_'"${SIDCAR}"'_LINUX_RELEASE_URL'` `eval echo '$ISTIO_'"${SIDCAR}"'_LINUX_RELEASE_PATH'`
+download_envoy_if_necessary `eval echo '$ISTIO_'"${SIDECAR}"'_LINUX_RELEASE_URL'` `eval echo '$ISTIO_'"${SIDECAR}"'_LINUX_RELEASE_PATH'`
 
 if [[ "$LOCAL_OS" == "Darwin" ]]; then
   # Download and extract the Envoy macOS release binary
-  download_envoy_if_necessary `eval echo '$ISTIO_'"${SIDCAR}"'_MACOS_RELEASE_URL'` `eval echo '$ISTIO_'"${SIDCAR}"'_MACOS_RELEASE_PATH'`
-  ISTIO_SIDCAR_NATIVE_PATH=`eval echo '$ISTIO_'"${SIDCAR}"'_MACOS_RELEASE_PATH'`
+  download_envoy_if_necessary `eval echo '$ISTIO_'"${SIDECAR}"'_MACOS_RELEASE_URL'` `eval echo '$ISTIO_'"${SIDECAR}"'_MACOS_RELEASE_PATH'`
+  ISTIO_SIDECAR_NATIVE_PATH=`eval echo '$ISTIO_'"${SIDECAR}"'_MACOS_RELEASE_PATH'`
 else
-  ISTIO_SIDCAR_NATIVE_PATH=`eval echo '$ISTIO_'"${SIDCAR}"'_LINUX_DEBUG_PATH'`
+  ISTIO_SIDECAR_NATIVE_PATH=`eval echo '$ISTIO_'"${SIDECAR}"'_LINUX_DEBUG_PATH'`
 fi
 
-if [ $SIDCAR = "Envoy" ] ; then 
+if [ $SIDECAR = "Envoy" ] ; then 
   # Copy native envoy binary to ISTIO_OUT
-  echo "Copying ${ISTIO_SIDCAR_NATIVE_PATH} to ${ISTIO_OUT}/envoy"
-  cp -f "${ISTIO_SIDCAR_NATIVE_PATH}" "${ISTIO_OUT}/envoy"
+  echo "Copying ${ISTIO_SIDECAR_NATIVE_PATH} to ${ISTIO_OUT}/envoy"
+  cp -f "${ISTIO_SIDECAR_NATIVE_PATH}" "${ISTIO_OUT}/envoy"
   
   # TODO(nmittler): Remove once tests no longer use the envoy binary directly.
   # circleCI expects this in the bin directory
@@ -264,10 +264,10 @@ if [ $SIDCAR = "Envoy" ] ; then
   cp -f "${ISTIO_OUT}/envoy" "${ISTIO_BIN}/envoy"
 fi
 
-if [ $SIDCAR = "MOSN" ] ; then 
+if [ $SIDECAR = "MOSN" ] ; then 
   # Copy native mosn binary to ISTIO_OUT
-  echo "Copying ${ISTIO_SIDCAR_NATIVE_PATH} to ${ISTIO_OUT}/mosn"
-  cp -f "${ISTIO_SIDCAR_NATIVE_PATH}" "${ISTIO_OUT}/mosn"
+  echo "Copying ${ISTIO_SIDECAR_NATIVE_PATH} to ${ISTIO_OUT}/mosn"
+  cp -f "${ISTIO_SIDECAR_NATIVE_PATH}" "${ISTIO_OUT}/mosn"
   
   # TODO(nmittler): Remove once tests no longer use the envoy binary directly.
   # circleCI expects this in the bin directory

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -86,10 +86,10 @@ spec:
 {{- end }}
 {{- end }}
         - name: istio-proxy
-{{- if contains "/" $.Values.global.proxy.image }}
-          image: "{{ $.Values.global.proxy.image }}"
+{{- if contains "/" $.Values.global.sidcar.image }}
+          image: "{{ $.Values.global.sidcar.image }}"
 {{- else }}
-          image: "{{ $.Values.global.hub }}/{{ $.Values.global.proxy.image }}:{{ $.Values.global.tag }}"
+          image: "{{ $.Values.global.hub }}/{{ $.Values.global.sidcar.image }}:{{ $.Values.global.tag }}"
 {{- end }}
           imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
           ports:
@@ -190,16 +190,17 @@ spec:
         {{- if $.Values.global.trustDomain }}
           - --trust-domain={{ $.Values.global.trustDomain }}
         {{- end }}
-          readinessProbe:
-            failureThreshold: 30
-            httpGet:
-              path: /healthz/ready
-              port: 15020
-              scheme: HTTP
-            initialDelaySeconds: 1
-            periodSeconds: 2
-            successThreshold: 1
-            timeoutSeconds: 1
+         # TODO support probe, Now MOSN don't support server_info API.
+         # readinessProbe:
+         #   failureThreshold: 30
+         #   httpGet:
+         #     path: /healthz/ready
+         #     port: 15020
+         #     scheme: HTTP
+         #   initialDelaySeconds: 1
+         #   periodSeconds: 2
+         #   successThreshold: 1
+         #   timeoutSeconds: 1
           resources:
 {{- if $spec.resources }}
 {{ toYaml $spec.resources | indent 12 }}

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -86,10 +86,10 @@ spec:
 {{- end }}
 {{- end }}
         - name: istio-proxy
-{{- if contains "/" $.Values.global.sidcar.image }}
-          image: "{{ $.Values.global.sidcar.image }}"
+{{- if contains "/" $.Values.global.sidecar.image }}
+          image: "{{ $.Values.global.sidecar.image }}"
 {{- else }}
-          image: "{{ $.Values.global.hub }}/{{ $.Values.global.sidcar.image }}:{{ $.Values.global.tag }}"
+          image: "{{ $.Values.global.hub }}/{{ $.Values.global.sidecar.image }}:{{ $.Values.global.tag }}"
 {{- end }}
           imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
           ports:
@@ -114,7 +114,7 @@ spec:
           - --log_output_level={{ $.Values.global.logging.level }}
         {{- end}}
           - --binaryPath
-          - {{ $.Values.global.sidcar.binaryPath }}
+          - {{ $.Values.global.sidecar.binaryPath }}
           - --drainDuration
           - '45s' #drainDuration
           - --parentShutdownDuration

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -113,6 +113,8 @@ spec:
         {{- if $.Values.global.logging.level }}
           - --log_output_level={{ $.Values.global.logging.level }}
         {{- end}}
+          - --binaryPath
+          - {{ $.Values.global.sidcar.binaryPath }}
           - --drainDuration
           - '45s' #drainDuration
           - --parentShutdownDuration

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -148,6 +148,8 @@ spec:
           - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
           - --serviceCluster
           - istio-pilot
+          - --binaryPath
+          - {{ .Values.global.sidcar.binaryPath }}
           - --templateFile
           - /etc/istio/proxy/envoy_pilot.yaml.tmpl
         {{- if $.Values.global.controlPlaneSecurityEnabled}}

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -148,8 +148,6 @@ spec:
           - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
           - --serviceCluster
           - istio-pilot
-          - --binaryPath
-          - {{ .Values.global.sidcar.binaryPath }}
           - --templateFile
           - /etc/istio/proxy/envoy_pilot.yaml.tmpl
         {{- if $.Values.global.controlPlaneSecurityEnabled}}

--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -105,10 +105,10 @@ initContainers:
   {{ end }}
 containers:
 - name: istio-proxy
-{{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
-  image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+{{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.sidcar.image) }}
+  image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.sidcar.image }}"
 {{- else }}
-  image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
+  image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.hub }}/{{ .Values.global.sidcar.image }}:{{ .Values.global.tag }}"
 {{- end }}
   ports:
   - containerPort: 15090
@@ -312,13 +312,14 @@ containers:
   {{- end }}
   imagePullPolicy: {{ .Values.global.imagePullPolicy }}
   {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` (valueOrDefault .Values.global.proxy.statusPort 0 )) `0` }}
-  readinessProbe:
-    httpGet:
-      path: /healthz/ready
-      port: {{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}
-    initialDelaySeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/initialDelaySeconds` .Values.global.proxy.readinessInitialDelaySeconds }}
-    periodSeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/periodSeconds` .Values.global.proxy.readinessPeriodSeconds }}
-    failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}
+  # TODO support probe, Now MOSN don't support server_info API. 
+  #readinessProbe:
+  #  httpGet:
+  #    path: /healthz/ready
+  #    port: {{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}
+  #  initialDelaySeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/initialDelaySeconds` .Values.global.proxy.readinessInitialDelaySeconds }}
+  #  periodSeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/periodSeconds` .Values.global.proxy.readinessPeriodSeconds }}
+  #  failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}
   {{ end -}}
   securityContext:
     allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}

--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -105,10 +105,10 @@ initContainers:
   {{ end }}
 containers:
 - name: istio-proxy
-{{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.sidcar.image) }}
-  image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.sidcar.image }}"
+{{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.sidecar.image) }}
+  image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.sidecar.image }}"
 {{- else }}
-  image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.hub }}/{{ .Values.global.sidcar.image }}:{{ .Values.global.tag }}"
+  image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.hub }}/{{ .Values.global.sidecar.image }}:{{ .Values.global.tag }}"
 {{- end }}
   ports:
   - containerPort: 15090

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -203,7 +203,7 @@ data:
       ### ADVANCED SETTINGS #############
       # Where should envoy's configuration be stored in the istio-proxy container
       configPath: "/etc/istio/proxy"
-      binaryPath: "/usr/local/bin/envoy"
+      binaryPath: "{{ .Values.global.sidcar.binaryPath }}"
       # The pseudo service name used for Envoy.
       serviceCluster: istio-proxy
       # These settings that determine how long an old Envoy

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -203,7 +203,7 @@ data:
       ### ADVANCED SETTINGS #############
       # Where should envoy's configuration be stored in the istio-proxy container
       configPath: "/etc/istio/proxy"
-      binaryPath: "{{ .Values.global.sidcar.binaryPath }}"
+      binaryPath: "{{ .Values.global.sidecar.binaryPath }}"
       # The pseudo service name used for Envoy.
       serviceCluster: istio-proxy
       # These settings that determine how long an old Envoy

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -114,10 +114,10 @@ global:
   # Default tag for Istio images.
   tag: 1.4-dev
   
-  # Default sidcar configration
-  # binaryPath is sidcar binary path
-  # image is sidcar and pilot-agent image, by make docker.proxyv2 .
-  sidcar:
+  # Default sidecar configration
+  # binaryPath is sidecar binary path
+  # image is sidecar and pilot-agent image, by make docker.proxyv2 .
+  sidecar:
     binaryPath: /usr/local/bin/mosn
     image: proxyv2
 

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -113,6 +113,10 @@ global:
 
   # Default tag for Istio images.
   tag: 1.4-dev
+  
+  # Default sidcar configration
+  sidcar:
+    binaryPath: /usr/local/bin/mosn
 
   # Comma-separated minimum per-scope logging level of messages to output, in the form of <scope>:<level>,<scope>:<level>
   # The control plane has different scopes depending on component, but can configure default log level across all components
@@ -466,7 +470,9 @@ global:
 
   # Use the Mesh Control Protocol (MCP) for configuring Mixer and
   # Pilot. Requires galley (`--set galley.enabled=true`).
-  useMCP: true
+  # TODO support MCP for MOSN
+  #useMCP: true
+  useMCP: false
 
   # The trust domain corresponds to the trust root of a system
   # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -115,8 +115,11 @@ global:
   tag: 1.4-dev
   
   # Default sidcar configration
+  # binaryPath is sidcar binary path
+  # image is sidcar and pilot-agent image, by make docker.proxyv2 .
   sidcar:
     binaryPath: /usr/local/bin/mosn
+    image: proxyv2
 
   # Comma-separated minimum per-scope logging level of messages to output, in the form of <scope>:<level>,<scope>:<level>
   # The control plane has different scopes depending on component, but can configure default log level across all components

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -46,7 +46,7 @@ ARG istio_version
 #COPY envoy /usr/local/bin/envoy
 
 # Install MOSN.
-# TODO dynamic set sidcar in Makefile
+# TODO dynamic set sidecar in Makefile
 COPY mosn /usr/local/bin/mosn
 
 # Environment variable indicating the exact proxy sha - for debugging or version-specific configs 

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -42,8 +42,12 @@ FROM ${BASE_DISTRIBUTION}
 ARG proxy_version
 ARG istio_version
 
-# Install Envoy.
-COPY envoy /usr/local/bin/envoy
+## Install Envoy.
+#COPY envoy /usr/local/bin/envoy
+
+# Install MOSN.
+# TODO dynamic set sidcar in Makefile
+COPY mosn /usr/local/bin/mosn
 
 # Environment variable indicating the exact proxy sha - for debugging or version-specific configs 
 ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -16,7 +16,7 @@ package envoy
 
 import (
 	"fmt"
-	"io/ioutil"
+	_ "io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -38,7 +38,11 @@ const (
 	epochFileTemplate = "envoy-rev%d.json"
 
 	// drainFile is the location of the bootstrap config used for draining on istio-proxy termination
-	drainFile = "/var/lib/istio/envoy/envoy_bootstrap_drain.json"
+	drainFile         = "/var/lib/istio/envoy/envoy_bootstrap_drain.json"
+	CmdStart          = "start"
+	ArgConfig         = "--config"
+	ArgServiceCluster = "--service-cluster"
+	ArgServiceNode    = "--service-node"
 )
 
 type envoy struct {
@@ -99,35 +103,44 @@ func (e *envoy) IsLive() bool {
 }
 
 func (e *envoy) args(fname string, epoch int, bootstrapConfig string) []string {
-	proxyLocalAddressType := "v4"
-	if isIPv6Proxy(e.NodeIPs) {
-		proxyLocalAddressType = "v6"
-	}
-	startupArgs := []string{"-c", fname,
-		"--restart-epoch", fmt.Sprint(epoch),
-		"--drain-time-s", fmt.Sprint(int(convertDuration(e.Config.DrainDuration) / time.Second)),
-		"--parent-shutdown-time-s", fmt.Sprint(int(convertDuration(e.Config.ParentShutdownDuration) / time.Second)),
-		"--service-cluster", e.Config.ServiceCluster,
-		"--service-node", e.Node,
-		"--max-obj-name-len", fmt.Sprint(e.Config.StatNameLength),
-		"--local-address-ip-version", proxyLocalAddressType,
-		"--log-format", fmt.Sprintf("[Envoy (Epoch %d)] ", epoch) + "[%Y-%m-%d %T.%e][%t][%l][%n] %v",
+	//proxyLocalAddressType := "v4"
+	//if isIPv6Proxy(e.NodeIPs) {
+	//	proxyLocalAddressType = "v6"
+	//}
+	// TODO MOSN need to be compatible with the following startup parameters.
+	//startupArgs := []string{"-c", fname,
+	//	"--restart-epoch", fmt.Sprint(epoch),
+	//	"--drain-time-s", fmt.Sprint(int(convertDuration(e.Config.DrainDuration) / time.Second)),
+	//	"--parent-shutdown-time-s", fmt.Sprint(int(convertDuration(e.Config.ParentShutdownDuration) / time.Second)),
+	//	"--service-cluster", e.Config.ServiceCluster,
+	//	"--service-node", e.Node,
+	//	"--max-obj-name-len", fmt.Sprint(e.Config.StatNameLength),
+	//	"--local-address-ip-version", proxyLocalAddressType,
+	//	"--log-format", fmt.Sprintf("[Envoy (Epoch %d)] ", epoch) + "[%Y-%m-%d %T.%e][%t][%l][%n] %v",
+	//}
+
+	//startupArgs = append(startupArgs, e.extraArgs...)
+
+	startupArgs := []string{CmdStart,
+		ArgConfig, fname,
+		ArgServiceCluster, e.Config.ServiceCluster,
+		ArgServiceNode, e.Node,
 	}
 
-	startupArgs = append(startupArgs, e.extraArgs...)
+	//TODO MOSN need to be support "--config-yaml" for override config.
+	// bootstrapConfig is depends on ISTIO_BOOTSTRAP_OVERRIDE env.
+	//if bootstrapConfig != "" {
+	//	bytes, err := ioutil.ReadFile(bootstrapConfig)
+	//	if err != nil {
+	//		log.Warnf("Failed to read bootstrap override %s, %v", bootstrapConfig, err)
+	//	} else {
+	//		startupArgs = append(startupArgs, "--config-yaml", string(bytes))
+	//	}
+	//}
 
-	if bootstrapConfig != "" {
-		bytes, err := ioutil.ReadFile(bootstrapConfig)
-		if err != nil {
-			log.Warnf("Failed to read bootstrap override %s, %v", bootstrapConfig, err)
-		} else {
-			startupArgs = append(startupArgs, "--config-yaml", string(bytes))
-		}
-	}
-
-	if e.Config.Concurrency > 0 {
-		startupArgs = append(startupArgs, "--concurrency", fmt.Sprint(e.Config.Concurrency))
-	}
+	//if e.Config.Concurrency > 0 {
+	//	startupArgs = append(startupArgs, "--concurrency", fmt.Sprint(e.Config.Concurrency))
+	//}
 
 	return startupArgs
 }

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -87,32 +87,32 @@ docker.sidecar_injector:$(ISTIO_DOCKER)/sidecar-injector
 # BUILD_PRE tells $(DOCKER_RULE) to run the command specified before executing a docker build
 # BUILD_ARGS tells  $(DOCKER_RULE) to execute a docker build with the specified commands
 
-#TODO support set sidcar dynamicly
-# The file must be named '$SIDCAR_BINARY_NAME', depends on the release.
+#TODO support set sidecar dynamicly
+# The file must be named '$SIDECAR_BINARY_NAME', depends on the release.
 
-ifeq ($(SIDCAR), MOSN)
-    export SIDCAR_BINARY_NAME = mosn
+ifeq ($(SIDECAR), MOSN)
+    export SIDECAR_BINARY_NAME = mosn
 endif
 
-ifeq ($(SIDCAR), Envoy)
-    export SIDCAR_BINARY_NAME = envoy
+ifeq ($(SIDECAR), Envoy)
+    export SIDECAR_BINARY_NAME = envoy
 endif
 
-${ISTIO_MOSN_LINUX_RELEASE_DIR}/${SIDCAR_BINARY_NAME}: ${ISTIO_MOSN_LINUX_RELEASE_PATH}
+${ISTIO_MOSN_LINUX_RELEASE_DIR}/${SIDECAR_BINARY_NAME}: ${ISTIO_MOSN_LINUX_RELEASE_PATH}
 	mkdir -p $(DOCKER_BUILD_TOP)/proxyv2
 ifdef DEBUG_IMAGE
-	cp ${ISTIO_MOSN_LINUX_DEBUG_PATH} ${ISTIO_MOSN_LINUX_RELEASE_DIR}/${SIDCAR_BINARY_NAME}
+	cp ${ISTIO_MOSN_LINUX_DEBUG_PATH} ${ISTIO_MOSN_LINUX_RELEASE_DIR}/${SIDECAR_BINARY_NAME}
 else
-	cp ${ISTIO_MOSN_LINUX_RELEASE_PATH} ${ISTIO_MOSN_LINUX_RELEASE_DIR}/${SIDCAR_BINARY_NAME}
+	cp ${ISTIO_MOSN_LINUX_RELEASE_PATH} ${ISTIO_MOSN_LINUX_RELEASE_DIR}/${SIDECAR_BINARY_NAME}
 endif
 
 # Default proxy image.
-docker.proxyv2: BUILD_PRE=chmod 755 ${SIDCAR_BINARY_NAME} pilot-agent istio-iptables istio-iptables.sh &&
+docker.proxyv2: BUILD_PRE=chmod 755 ${SIDECAR_BINARY_NAME} pilot-agent istio-iptables istio-iptables.sh &&
 docker.proxyv2: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REPO_SHA} --build-arg istio_version=${VERSION} --build-arg BASE_VERSION=${BASE_VERSION}
 docker.proxyv2: tools/packaging/common/envoy_bootstrap_v2.json
 docker.proxyv2: tools/packaging/common/envoy_bootstrap_drain.json
 docker.proxyv2: install/gcp/bootstrap/gcp_envoy_bootstrap.json
-docker.proxyv2: $(ISTIO_MOSN_LINUX_RELEASE_DIR)/${SIDCAR_BINARY_NAME}
+docker.proxyv2: $(ISTIO_MOSN_LINUX_RELEASE_DIR)/${SIDECAR_BINARY_NAME}
 docker.proxyv2: $(ISTIO_OUT_LINUX)/pilot-agent
 docker.proxyv2: pilot/docker/Dockerfile.proxyv2
 docker.proxyv2: pilot/docker/envoy_pilot.yaml.tmpl
@@ -127,7 +127,7 @@ docker.proxytproxy: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REP
 docker.proxytproxy: tools/packaging/common/envoy_bootstrap_v2.json
 docker.proxytproxy: tools/packaging/common/envoy_bootstrap_drain.json
 docker.proxytproxy: install/gcp/bootstrap/gcp_envoy_bootstrap.json
-docker.proxytproxy: $(ISTIO_MOSN_LINUX_RELEASE_DIR)/${SIDCAR_BINARY_NAME}
+docker.proxytproxy: $(ISTIO_MOSN_LINUX_RELEASE_DIR)/${SIDECAR_BINARY_NAME}
 docker.proxytproxy: $(ISTIO_OUT_LINUX)/pilot-agent
 docker.proxytproxy: pilot/docker/Dockerfile.proxytproxy
 docker.proxytproxy: pilot/docker/envoy_pilot.yaml.tmpl
@@ -162,7 +162,7 @@ docker.app_sidecar: tools/packaging/common/istio-node-agent-start.sh
 docker.app_sidecar: tools/packaging/deb/postinst.sh
 docker.app_sidecar: pkg/test/echo/docker/echo-start.sh
 docker.app_sidecar: $(ISTIO_DOCKER)/certs
-docker.app_sidecar: $(ISTIO_MOSN_LINUX_RELEASE_DIR)/${SIDCAR_BINARY_NAME}
+docker.app_sidecar: $(ISTIO_MOSN_LINUX_RELEASE_DIR)/${SIDECAR_BINARY_NAME}
 docker.app_sidecar: $(ISTIO_OUT_LINUX)/pilot-agent
 docker.app_sidecar: $(ISTIO_OUT_LINUX)/node_agent
 docker.app_sidecar: $(ISTIO_OUT_LINUX)/client

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -149,29 +149,31 @@
     ],
     "stats_matcher": {
       "inclusion_list": {
-        "patterns": [
-          {
-          "prefix": "reporter="
-          },
-          {
-          "prefix": "component"
-          },
-          {{- range $a, $s := .inclusionPrefix }}
-          {
-          "prefix": "{{$s}}"
-          },
-          {{- end }}
-          {{- range $a, $s := .inclusionSuffix }}
-          {
-          "suffix": "{{$s}}"
-          },
-          {{- end }}
-          {{- range $a, $s := .inclusionRegexps }}
-          {
-          "regex": "{{js $s}}"
-          },
-          {{- end }}
-        ]
+        "patterns": [{
+          "prefix": "cluster_manager"
+        },
+        {
+        "prefix": "reporter="
+        },
+        {
+        "prefix": "component"
+        },        
+        {
+          "prefix": "listener_manager"
+        },
+        {
+          "prefix": "http_mixer_filter"
+        },
+        {
+          "prefix": "tcp_mixer_filter"
+        },
+        {
+          "prefix": "server"
+        },
+        {
+          "prefix": "cluster.xds-grpc"
+        }
+      ]
       }
     }
   },


### PR DESCRIPTION
Now MOSN could run pass bookinfo case in istio-1.4.6. Use as follows，

### Render the  Istio yaml 

```bash
git clone  -b feature-mosn_adapter  https://github.com/mosn/istio.git &  cd istio 

helm template install/kubernetes/helm/istio-init --set global.hub=docker.io/istio --set global.tag=1.4.6  --name istio-init --namespace istio-system >istio_init.yaml

helm template install/kubernetes/helm/istio --set global.sidecar.binaryPath=/usr/local/bin/mosn  --set global.hub=docker.io/istio --set global.tag=1.4.6  --set global.sidecar.image=mosnio/proxyv2:1.4.6-mosn  --name istio --namespace istio-system >istio.yaml
```

### Install Istio with kubectl

```bash
kubectl create namespace istio-system
kubectl apply -f istio_init.yaml
kubectl apply -f istio.yaml
```

A few minutes later, you can execute `kubectl get pod -n istio-system` and see something like follows. Then you can run the bookinfo example by [bookinfo doc](https://mosn.io/zh/docs/quick-start/istio/#bookinfo-%E5%AE%9E%E9%AA%8C).

```
NAME                                        READY   STATUS      RESTARTS   AGE
istio-citadel-6b7796cbc7-8q72s              1/1     Running     0          11h
istio-galley-5545dff574-6qls6               1/1     Running     0          11h
istio-ingressgateway-79b75c4db-8w646        1/1     Running     0          59m
istio-init-crd-10-1.4-dev-9m7g6             0/1     Completed   0          11h
istio-init-crd-11-1.4-dev-j27vt             0/1     Completed   0          11h
istio-init-crd-14-1.4-dev-4h9ts             0/1     Completed   0          11h
istio-pilot-6654897fc6-vh299                2/2     Running     0          10h
istio-policy-68774796b8-qq5kz               2/2     Running     0          9h
istio-security-post-install-1.4-dev-g98ws   0/1     Completed   0          11h
istio-sidecar-injector-f7b64d984-hw8p4      1/1     Running     0          11h
istio-telemetry-5f5d94c78-zw847             2/2     Running     0          9h
prometheus-6c9c8f9c97-mkcnp                 1/1     Running     0          11h
```
