### PR TITLE
Support MOSN as a sidecar on the Istio-1.5.x.

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -152,6 +152,13 @@ export ISTIO_ENVOY_LINUX_RELEASE_DIR ?= ${TARGET_OUT_LINUX}/release
 export ISTIO_ENVOY_LINUX_RELEASE_NAME ?= envoy-${ISTIO_ENVOY_VERSION}
 export ISTIO_ENVOY_LINUX_RELEASE_PATH ?= ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/${ISTIO_ENVOY_LINUX_RELEASE_NAME}
 
+# MOSN generic vars.
+export ISTIO_MOSN_BASE_URL ?= https://github.com/mosn/mosn/releases/download/
+export ISTIO_MOSN_VERSION ?= 0.10.0
+export ISTIO_MOSN_URL ?= ${ISTIO_MOSN_BASE_URL}/${ISTIO_MOSN_VERSION}/mosn
+export ISTIO_MOSN_LINUX_PATH ?= ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/mosn-${ISTIO_MOSN_VERSION}
+
+
 # Envoy macOS vars.
 # TODO Change url when official envoy release for macOS is available
 export ISTIO_ENVOY_MACOS_VERSION ?= 1.0.2

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -91,6 +91,29 @@ function download_envoy_if_necessary () {
   fi
 }
 
+function download_mosn_if_necessary () {
+  if [[ ! -f "$2" ]] ; then
+    # Enter the output directory.
+    mkdir -p "$(dirname "$2")"
+    pushd "$(dirname "$2")"
+
+    # Download and extract the binary to the output directory.
+    echo "Downloading MOSN: ${DOWNLOAD_COMMAND} $1 to $2"
+    time ${DOWNLOAD_COMMAND} --header "${AUTH_HEADER:-}" "$1" > mosn_binary
+
+    # Copy the extracted binary to the output location
+    cp mosn_binary "$2"
+
+    # Remove the extracted binary.
+    rm -rf mosn_binary
+
+    # Make a copy named just "mosn" in the same directory (overwrite if necessary).
+    echo "Copying $2 to $(dirname "$2")/mosn"
+    cp -f "$2" "$(dirname "$2")/mosn"
+    popd
+  fi
+}
+
 # Downloads WebAssembly based plugin if it doesn't already exist.
 # Params:
 #   $1: The URL of the WebAssembly file to be downloaded.
@@ -193,18 +216,28 @@ set_download_command
 if [[ -n "${DEBUG_IMAGE:-}" ]]; then
   # Download and extract the Envoy linux debug binary.
   download_envoy_if_necessary "${ISTIO_ENVOY_LINUX_DEBUG_URL}" "$ISTIO_ENVOY_LINUX_DEBUG_PATH"
+
+  # Download and extract the mosn linux binary.
+  ISTIO_MOSN_LINUX_PATH=$(dirname "$ISTIO_ENVOY_LINUX_DEBUG_PATH")/mosn-${ISTIO_MOSN_VERSION}
+  download_envoy_if_necessary "${ISTIO_MOSN_URL}" "${ISTIO_MOSN_LINUX_PATH}"
 else
   echo "Skipping envoy debug. Set DEBUG_IMAGE to download."
 fi
 
-# Download and extract the Envoy linux release binary.
+# Download and extract the Envoy/MOSN linux release binary.
 download_envoy_if_necessary "${ISTIO_ENVOY_LINUX_RELEASE_URL}" "$ISTIO_ENVOY_LINUX_RELEASE_PATH"
 
+ISTIO_MOSN_LINUX_PATH=$(dirname "$ISTIO_ENVOY_LINUX_RELEASE_PATH")/mosn-${ISTIO_MOSN_VERSION}
+download_mosn_if_necessary "${ISTIO_MOSN_URL}" "${ISTIO_MOSN_LINUX_PATH}"
+
 if [[ "$GOOS_LOCAL" == "darwin" ]]; then
-  # Download and extract the Envoy macOS release binary
+  # Download and extract the Envoy/MOSN macOS release binary
   download_envoy_if_necessary "${ISTIO_ENVOY_MACOS_RELEASE_URL}" "$ISTIO_ENVOY_MACOS_RELEASE_PATH"
+  ISTIO_MOSN_LINUX_PATH=$(dirname "$ISTIO_ENVOY_MACOS_RELEASE_PATH")/mosn-${ISTIO_MOSN_VERSION}
+  download_mosn_if_necessary "${ISTIO_MOSN_URL}" "${ISTIO_MOSN_LINUX_PATH}"
   ISTIO_ENVOY_NATIVE_PATH=${ISTIO_ENVOY_MACOS_RELEASE_PATH}
 else
+  ISTIO_MOSN_LINUX_PATH=$(dirname "$ISTIO_ENVOY_LINUX_RELEASE_PATH")/mosn-${ISTIO_MOSN_VERSION}
   ISTIO_ENVOY_NATIVE_PATH=${ISTIO_ENVOY_LINUX_RELEASE_PATH}
 fi
 
@@ -216,12 +249,18 @@ do
   download_wasm_if_necessary "${FILTER_WASM_URL}" "${WASM_RELEASE_DIR}"/"${plugin//_/-}"-filter.wasm
 done
 
-# Copy native envoy binary to ISTIO_OUT
+# Copy native envoy/mosn binary to ISTIO_OUT
 echo "Copying ${ISTIO_ENVOY_NATIVE_PATH} to ${ISTIO_OUT}/envoy"
 cp -f "${ISTIO_ENVOY_NATIVE_PATH}" "${ISTIO_OUT}/envoy"
 
-# Copy the envoy binary to ISTIO_OUT_LINUX if the local OS is not Linux
+echo "Copying ${ISTIO_MOSN_LINUX_PATH} to ${ISTIO_OUT}/mosn"
+cp -f "${ISTIO_MOSN_LINUX_PATH}" "${ISTIO_OUT}/mosn"
+
+# Copy the envoy/mosn binary to ISTIO_OUT_LINUX if the local OS is not Linux
 if [[ "$GOOS_LOCAL" != "linux" ]]; then
    echo "Copying ${ISTIO_ENVOY_LINUX_RELEASE_PATH} to ${ISTIO_OUT_LINUX}/envoy"
-  cp -f "${ISTIO_ENVOY_LINUX_RELEASE_PATH}" "${ISTIO_OUT_LINUX}/envoy"
+   cp -f "${ISTIO_ENVOY_LINUX_RELEASE_PATH}" "${ISTIO_OUT_LINUX}/envoy"
+
+   echo "Copying ${ISTIO_MOSN_LINUX_PATH} to ${ISTIO_OUT_LINUX}/mosn"
+   cp -f "${ISTIO_MOSN_LINUX_PATH}" "${ISTIO_OUT_LINUX}/mosn"
 fi

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -43,6 +43,9 @@ ARG istio_version
 # Install Envoy.
 COPY envoy /usr/local/bin/envoy
 
+# Install mosn.
+COPY mosn /usr/local/bin/mosn
+
 # Environment variable indicating the exact proxy sha - for debugging or version-specific configs 
 ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version
 # Environment variable indicating the exact build, for debugging

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -51,8 +51,9 @@ const (
 	// ConfigPathDir config directory for storing envoy json config files.
 	ConfigPathDir = "/etc/istio/proxy"
 
-	// BinaryPathFilename envoy binary location
-	BinaryPathFilename = "/usr/local/bin/envoy"
+	// TODO default use envoy at the istio-1.6.x.
+	// BinaryPathFilename mosn binary location
+	BinaryPathFilename = "/usr/local/bin/mosn"
 
 	// ServiceClusterName service cluster name used in xDS calls
 	ServiceClusterName = "istio-proxy"

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -93,16 +93,26 @@ else
 	cp ${ISTIO_ENVOY_LINUX_RELEASE_PATH} ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/envoy
 endif
 
+# The file must be named 'mosn', depends on the release.
+#${ISTIO_ENVOY_LINUX_RELEASE_DIR}/mosn: $(dirname ${ISTIO_ENVOY_LINUX_RELEASE_PATH})/mosn
+${ISTIO_ENVOY_LINUX_RELEASE_DIR}/mosn: ${ISTIO_MOSN_LINUX_PATH}
+ifdef DEBUG_IMAGE
+	cp $(dirname $ISTIO_ENVOY_LINUX_DEBUG_PATH)/mosn ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/mosn
+else
+	cp $(dirname ${ISTIO_ENVOY_LINUX_RELEASE_PATH})/mosn ${ISTIO_ENVOY_LINUX_RELEASE_DIR}/mosn
+endif
+
 # rule for wasm extensions.
 $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/stats-filter.wasm: init
 $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/metadata-exchange-filter.wasm: init
 
 # Default proxy image.
-docker.proxyv2: BUILD_PRE=&& chmod 755 envoy pilot-agent istio-iptables
+docker.proxyv2: BUILD_PRE=&& chmod 755 envoy mosn pilot-agent istio-iptables
 docker.proxyv2: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REPO_SHA} --build-arg istio_version=${VERSION} --build-arg BASE_VERSION=${BASE_VERSION}
 docker.proxyv2: tools/packaging/common/envoy_bootstrap_v2.json
 docker.proxyv2: install/gcp/bootstrap/gcp_envoy_bootstrap.json
 docker.proxyv2: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/envoy
+docker.proxyv2: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/mosn
 docker.proxyv2: $(ISTIO_OUT_LINUX)/pilot-agent
 docker.proxyv2: pilot/docker/Dockerfile.proxyv2
 docker.proxyv2: pilot/docker/envoy_pilot.yaml.tmpl
@@ -118,6 +128,7 @@ docker.proxytproxy: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REP
 docker.proxytproxy: tools/packaging/common/envoy_bootstrap_v2.json
 docker.proxytproxy: install/gcp/bootstrap/gcp_envoy_bootstrap.json
 docker.proxytproxy: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/envoy
+docker.proxytproxy: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/mosn
 docker.proxytproxy: $(ISTIO_OUT_LINUX)/pilot-agent
 docker.proxytproxy: pilot/docker/Dockerfile.proxytproxy
 docker.proxytproxy: pilot/docker/envoy_pilot.yaml.tmpl

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -182,21 +182,27 @@
           {
           "prefix": "component"
           },
-          {{- range $a, $s := .inclusionPrefix }}
           {
-          "prefix": "{{$s}}"
+          "prefix": "cluster_manager"
           },
-          {{- end }}
-          {{- range $a, $s := .inclusionSuffix }}
           {
-          "suffix": "{{$s}}"
+          "prefix": "listener_manager"
           },
-          {{- end }}
-          {{- range $a, $s := .inclusionRegexps }}
           {
-          "regex": "{{js $s}}"
+          "prefix": "http_mixer_filter"
           },
-          {{- end }}
+          {
+          "prefix": "tcp_mixer_filter"
+          },
+          {
+          "prefix": "server"
+          },
+          {
+          "prefix": "cluster.xds-grpc"
+          },
+          {
+          "suffix": "ssl_context_update_by_sds"
+          }
         ]
       }
     }
@@ -274,6 +280,23 @@
               "h2"
             ],
             {{ if eq .sds_uds_path "unix:/etc/istio/proxy/SDS" }}
+             "tls_certificate_sds_secret_configs":[
+              {
+                "name":"default",
+                "sds_config":{
+                  "api_config_source":{
+                    "api_type":"GRPC",
+                    "grpc_services":[
+                      {
+                        "envoy_grpc":{
+                          "cluster_name": "sds-grpc"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ],
             "validation_context": {
               "trusted_ca": {
                 {{ if eq .pilot_cert_provider "kubernetes" }}
@@ -361,7 +384,7 @@
               }
             }
             {{ end }}
-          },
+          }
         },
         {{ else }}
         "tls_context": {
@@ -391,7 +414,7 @@
         {{ end }}
         "hosts": [
           {
-            "socket_address": {{ .pilot_grpc_address }}
+             "socket_address": {"address": "istio-pilot.istio-system.svc", "port_value": 15010}
           }
         ],
         "circuit_breakers": {


### PR DESCRIPTION
Now we could use the command `make docker.proxyv2` to build `proxyv2` image, And the image contains the binary of `envoy` and `mosn`, and  we colud choose one as the sidecar via the `istioctl` parameter `--set meshConfig.defaultConfig.binaryPath`.